### PR TITLE
fix processor and qwen_vl_utils resize conflict

### DIFF
--- a/src/training/data.py
+++ b/src/training/data.py
@@ -204,17 +204,17 @@ class SupervisedDataset(Dataset):
             gpt_response = f"{gpt_response['content']}{DEFAULT_IM_END_TOKEN}\n"
             
             if DEFAULT_IMAGE_TOKEN in user_input:
-                inputs = processor(text=[user_input], images=images, videos=videos, padding=False, return_tensors='pt')
+                inputs = processor(text=[user_input], images=images, videos=videos, padding=False, do_resize=False, return_tensors='pt')
                 prompt_input_ids = inputs['input_ids']
                 all_pixel_values.append(inputs[pixel_key])
                 all_image_grid_thw.append(inputs[grid_key])
             
             elif DEFAULT_VIDEO_TOKEN in user_input:
                 if "Qwen2.5" in self.model_id:
-                    inputs = processor(text=[user_input], images=images, videos=videos, padding=False, return_tensors='pt', **video_kwargs)
+                    inputs = processor(text=[user_input], images=images, videos=videos, padding=False, do_resize=False, return_tensors='pt', **video_kwargs)
                     all_second_gird.extend(inputs["second_per_grid_ts"])
                 else:
-                    inputs = processor(text=[user_input], images=images, videos=videos, padding=False, return_tensors='pt')
+                    inputs = processor(text=[user_input], images=images, videos=videos, padding=False, do_resize=False, return_tensors='pt')
                 prompt_input_ids = inputs['input_ids']
                 all_pixel_values.append(inputs[pixel_key])
                 all_image_grid_thw.append(inputs[grid_key])


### PR DESCRIPTION
Hi! The smart_resize in 
https://github.com/huggingface/transformers/blob/953196a43dae6a3c474165fba7d215fcbc7b7730/src/transformers/models/qwen2_vl/image_processing_qwen2_vl_fast.py#L202
 conflicts with `smart_resize` of qwen_vl_utils in https://github.com/2U1/Qwen2-VL-Finetune/blob/274b1f1263cb9414cc14d2176916babe9ba6d2f9/src/training/data.py#L68. When we use a utral small or large pixels out of the range of the default `image_processing_qwen2_vl_fast`, the line will cause inconsistent behaviors.