### PR TITLE
[Fix] Resolve Qwen2.5-VL Processor Saving Issue

### DIFF
--- a/src/train/train_sft.py
+++ b/src/train/train_sft.py
@@ -228,9 +228,12 @@ def train():
         if local_rank == 0 or local_rank == -1:
             model.config.save_pretrained(training_args.output_dir)
             model.save_pretrained(training_args.output_dir, state_dict=state_dict)
+            processor.save_pretrained(training_args.output_dir)
             torch.save(non_lora_state_dict, os.path.join(training_args.output_dir, "non_lora_state_dict.bin"))
     else:
         safe_save_model_for_hf_trainer(trainer, output_dir=training_args.output_dir)
+        if local_rank == 0 or local_rank == -1:Add commentMore actions
+            processor.save_pretrained(training_args.output_dir)
 
 
 

--- a/src/train/train_sft.py
+++ b/src/train/train_sft.py
@@ -232,8 +232,6 @@ def train():
             torch.save(non_lora_state_dict, os.path.join(training_args.output_dir, "non_lora_state_dict.bin"))
     else:
         safe_save_model_for_hf_trainer(trainer, output_dir=training_args.output_dir)
-        if local_rank == 0 or local_rank == -1:Add commentMore actions
-            processor.save_pretrained(training_args.output_dir)
 
 
 


### PR DESCRIPTION
[Fix] Resolve Qwen2.5-VL Processor Saving Issue

### What this PR does / PR Content
This Pull Request addresses an issue where the `processor` object for the Qwen2.5-VL model was not being correctly saved and loaded. Previously, the `processor` would be initialized as `None` when loading the model, making it unusable without manual intervention.

### Why this change / Reason for Change
When attempting to save and then reload the Qwen2.5-VL model along with its associated `processor`, the `processor` object was not being properly restored. This led to essential configuration components, crucial for model inference, being missing upon reloading. Users had to manually reconfigure the `processor` every time they wanted to reuse a previously saved model. This change ensures the persistence of the `processor`, significantly improving user convenience and model usability.