### PR TITLE
Add validation to QwenSFT training

### DIFF
--- a/src/dataset/sft_dataset.py
+++ b/src/dataset/sft_dataset.py
@@ -266,8 +266,17 @@ def make_supervised_data_module(model_id, processor, data_args):
     sft_dataset = SupervisedDataset(
         data_path=data_args.data_path, processor=processor, data_args=data_args, model_id=model_id
     )
+    eval_dataset = None
+    if data_args.eval_path is not None:
+        eval_dataset = SupervisedDataset(
+              data_path=data_args.eval_path,
+              processor=processor,
+              data_args=data_args,
+              model_id=model_id
+          )
+        
     data_collator = DataCollatorForSupervisedDataset(pad_token_id=processor.tokenizer.pad_token_id)
 
     return dict(train_dataset=sft_dataset,
-                eval_dataset=None,
+                eval_dataset=eval_dataset,
                 data_collator=data_collator)


### PR DESCRIPTION
안녕하세요! 
QwenSFT training 중에 validation 코드를 추가했고 validation loss가 성공적으로 나오는 것을 확인했습니다.

- src/dataset/sft_dataset.py ( line 269 )
  - eval_path가 None이 아닌 경우 eval_dataset을 sft_dataset와 같은 방법으로 생성합니다.
  
- src/trainer/sft_trainer.py ( line 196 )
  - sft_dataset.py만 수정해줬을 때는 validation은 되지만 loss가 반환되지 않아서 Trainer의 prediction_step을 오버라이딩 했습니다.
  - 이로인해 eval_path가 존재하면 무조건 loss를 구하게 됩니다.
  - 원래 Trainer의 prediction_step가 호출되면서  어떤 부분으로 인해서 loss가 반환되지 않는지는 정확히 확인하지 못했습니다. 그러나 labels가 inputs에 존재하면 `outputs = model(**inputs)` 코드는 loss를 반환하고 그렇지 않으면 loss = None을 반환합니다.
  - 참고링크 : https://huggingface.co/docs/transformers/ko/main_classes/trainer

훈련 sh 파일에 다음과 같은 기본 인자를 사용했습니다. ( params.py는 수정하지 않았습니다. )
```
BATCH_PER_DEVICE  = 8
EVAL_PATH  = "eval_path"

--eval_steps 1 \
--eval_strategy "steps" \
--per_device_eval_batch_size $BATCH_PER_DEVICE \
--eval_path $EVAL_PATH \
```
좋은 레포지토리를 제공해주셔서 많은 도움이 되었습니다. 감사합니다!