### PR TITLE
Feat/liger kernel 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,6 +705,7 @@ Most of the training arugments are same as SFT, but few other arguments are adde
 - `--max_completion_length` (int): Max length for the completion (default: 256)
 - `--max_prompt_length` (int): Max length for the prompt (default: 512)
 - `--beta` (float): KL Coefficient. (default: 0.04)
+- `--liger_grpo_loss_type` (str): When `--use_liger_loss True`, choose the GRPO loss variant exposed by liger-kernel 0.8.0. One of `grpo`, `bnpo`, `dr_grpo`, `dapo` (LigerFusedLinearGRPOLoss default), `cispo`, `sapo`, `luspo`. Defaults to `None`, which keeps Liger's built-in default. `dr_grpo` also requires `--max_completion_length`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository contains a script for training [Qwen2-VL](https://huggingface.co
 
 ## Update
 
+- [2026/05/18] 🔥**Upgrade to `liger_kernel==0.8.0`.** Liger 0.8.0 adds official patches for `qwen3_5` / `qwen3_5_moe` and ships **LigerExperts**, a fused MoE expert kernel that auto-accelerates `qwen3_vl_moe` and `qwen3_5_moe` under `--use_liger_kernel True`. The 0.7-era hardcoded fallback that force-disabled Liger for Qwen3.5 in SFT/DPO/GRPO has been removed, and the `mm_token_type_ids` GRPO wrapper is now skipped automatically on Liger ≥ 0.8.0 (kept as a no-op shim for older installs).
 - [2026/03/07] 🔥**Supports reasoning mode training for Qwen3-VL and Qwen3.5**
 - [2026/03/07] 🔥**Supports Qwen3.5 Series.**
 - [2026/03/07] Supports Qwen3-VL classification
@@ -385,7 +386,8 @@ Adding the new domain-specific data on top of the general data from open-source 
 
 ## Supervised Fine Tuning
 
-⚠️**For Qwen3-VL models, using liger-kernel with full fine-tuning is awfully slow. I recommend turning off liger-kernel or use zero2 with full-finetuning.**<br><br>
+⚠️**For dense Qwen3-VL models, full fine-tuning with liger-kernel can be slow. Consider turning off liger-kernel or switching to zero2 in that case.**<br>
+✅**Qwen3-VL-MoE and Qwen3.5-MoE use Liger 0.8.0's fused `LigerExperts` kernel automatically, so leaving `--use_liger_kernel True` is recommended for MoE variants.**<br><br>
 
 **Tip:** You could use `adamw_bnb_8bit` for optimizer to save memory.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ jupyter_client==8.6.3
 jupyter_core==5.7.2
 jupyterlab_widgets==3.0.14
 kiwisolver==1.4.9
-liger_kernel==0.7.0
+liger_kernel==0.8.0
 markdown-it-py==3.0.0
 MarkupSafe==2.1.5
 matplotlib==3.10.6

--- a/scripts/finetune_grpo.sh
+++ b/scripts/finetune_grpo.sh
@@ -12,6 +12,11 @@ export PYTHONPATH=src:$PYTHONPATH
 # If you switch MODEL_NAME to a Qwen3.5 model, set `--disable_flash_attn2 True`.
 # Flash Attention 2 raised CUDA errors for the Qwen3.5 series in local tests, so SDPA is the stable path for now.
 
+# Optional Liger GRPO loss variant (requires --use_liger_loss True and liger-kernel >= 0.8.0):
+#   --liger_grpo_loss_type <name>   where <name> is one of:
+#     grpo | bnpo | dr_grpo | dapo (default) | cispo | sapo | luspo
+# Note: dr_grpo additionally requires --max_completion_length to be set.
+
 deepspeed src/train/train_grpo.py \
     --deepspeed scripts/zero3.json \
     --use_liger_loss True \

--- a/src/params.py
+++ b/src/params.py
@@ -271,6 +271,17 @@ class GRPOArguments(GRPOConfigTRL):
     max_completion_length: int = 256
     max_prompt_length: int = 512
     use_liger_loss: bool = True
+    liger_grpo_loss_type: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Override the Liger GRPO loss variant when --use_liger_loss is True. "
+                "liger-kernel 0.8.0 supports: 'grpo', 'bnpo', 'dr_grpo', 'dapo' (default), "
+                "'cispo', 'sapo', 'luspo'. When None, the underlying LigerFusedLinearGRPOLoss "
+                "default is used. Note: 'dr_grpo' also requires --max_completion_length."
+            )
+        },
+    )
 
 
 @dataclass

--- a/src/train/train_dpo.py
+++ b/src/train/train_dpo.py
@@ -142,10 +142,6 @@ def train():
             attn_implementation="sdpa" if training_args.disable_flash_attn2 else "flash_attention_2",
             **bnb_model_from_pretrained_args,
         )
-    if training_args.use_liger_loss and model.config.model_type in {"qwen3_5", "qwen3_5_moe"}:
-        rank0_print(f"Disabling Liger loss for unsupported model_type: {model.config.model_type}")
-        training_args.use_liger_loss = False
-
     model.config.use_cache = False
     model_to_configure = model
     configure_llm(model_to_configure, training_args)

--- a/src/train/train_grpo.py
+++ b/src/train/train_grpo.py
@@ -137,11 +137,6 @@ def train():
         attn_implementation="sdpa" if training_args.disable_flash_attn2 else "flash_attention_2",
         **bnb_model_from_pretrained_args,
     )
-    if training_args.use_liger_loss and model.config.model_type in {"qwen3_5", "qwen3_5_moe"}:
-        rank0_print(f"Disabling Liger loss for unsupported model_type: {model.config.model_type}")
-        training_args.use_liger_loss = False
-
-
     model.config.use_cache = False
     model_to_configure = model
     configure_llm(model_to_configure, training_args)

--- a/src/train/train_sft.py
+++ b/src/train/train_sft.py
@@ -134,11 +134,6 @@ def train():
         attn_implementation="sdpa" if training_args.disable_flash_attn2 else "flash_attention_2",
         **bnb_model_from_pretrained_args,
     )
-    if training_args.use_liger_kernel and model.config.model_type in {"qwen3_5", "qwen3_5_moe"}:
-        rank0_print(f"Disabling Liger kernel for unsupported model_type: {model.config.model_type}")
-        training_args.use_liger_kernel = False
-        if hasattr(training_args, "liger_kernel_config"):
-            training_args.liger_kernel_config = None
 
     model.config.use_cache = False
     model_to_configure = model

--- a/src/trainer/grpo_trainer.py
+++ b/src/trainer/grpo_trainer.py
@@ -133,6 +133,23 @@ class QwenGRPOTrainer(GRPOTrainer):
         _ensure_mm_token_type_ids_generate_compat(self.model)
         _ensure_mm_token_type_ids_generate_compat(getattr(self, "model_wrapped", None))
         _ensure_mm_token_type_ids_generate_compat(getattr(self, "ref_model", None))
+        self._apply_liger_grpo_loss_type_override()
+
+    def _apply_liger_grpo_loss_type_override(self) -> None:
+        """If the user passed --liger_grpo_loss_type, swap the loss variant on
+        the LigerFusedLinearGRPOLoss instance that TRL's GRPOTrainer set up.
+        Available types depend on liger-kernel >= 0.8.0:
+        'grpo', 'bnpo', 'dr_grpo', 'dapo', 'cispo', 'sapo', 'luspo'."""
+        desired = getattr(self.args, "liger_grpo_loss_type", None)
+        if not desired:
+            return
+        liger_grpo_loss = getattr(self, "liger_grpo_loss", None)
+        if liger_grpo_loss is None or not hasattr(liger_grpo_loss, "loss_type"):
+            return
+        previous = liger_grpo_loss.loss_type
+        liger_grpo_loss.loss_type = desired
+        if getattr(self, "accelerator", None) is None or self.accelerator.is_main_process:
+            print(f"[QwenGRPOTrainer] liger_grpo_loss.loss_type: {previous!r} -> {desired!r}")
 
     def _set_signature_columns_if_needed(self):
         # If `self.args.remove_unused_columns` is True, non-signature columns are removed.

--- a/src/trainer/grpo_trainer.py
+++ b/src/trainer/grpo_trainer.py
@@ -3,8 +3,10 @@ import inspect
 import torch
 from pathlib import Path
 from types import MethodType
-import torch.nn as nn
 from typing import Any
+
+import torch.nn as nn
+from packaging.version import Version
 
 import trl.import_utils as trl_import_utils
 from transformers.trainer import (
@@ -78,7 +80,24 @@ def _iter_generate_models(model):
             stack.append(base_model)
 
 
+def _liger_exposes_mm_token_type_ids() -> bool:
+    """liger-kernel >= 0.8.0 restored `mm_token_type_ids` on the patched VL forward
+    (see linkedin/Liger-Kernel#1120, #1140). Older releases drop it from the
+    signature so we still need the runtime wrapper below for them."""
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+    except ImportError:
+        return False
+    try:
+        return Version(version("liger_kernel")) >= Version("0.8.0")
+    except PackageNotFoundError:
+        return False
+
+
 def _ensure_mm_token_type_ids_generate_compat(model):
+    if _liger_exposes_mm_token_type_ids():
+        return
+
     for candidate in _iter_generate_models(model):
         config = getattr(candidate, "config", None)
         model_type = getattr(config, "model_type", None)
@@ -93,9 +112,9 @@ def _ensure_mm_token_type_ids_generate_compat(model):
         if "mm_token_type_ids" in forward_sig.parameters:
             continue
 
-        # Liger replaces the multimodal forward without exposing `mm_token_type_ids`
-        # in the Python signature. Generation validation then rejects the kwarg
-        # before it reaches the underlying Qwen-VL model.
+        # Liger < 0.8.0 replaces the multimodal forward without exposing
+        # `mm_token_type_ids` in the Python signature. Generation validation
+        # then rejects the kwarg before it reaches the underlying Qwen-VL model.
         original_forward = candidate.forward
 
         def forward_with_mm_token_type_ids(self, *args, mm_token_type_ids=None, **kwargs):


### PR DESCRIPTION
This PR bumps the liger-kernel version from 0.7.0 to 0.8.0. This upgrade brings in support for different GRPO loss types within the kernel.
Furthermore, we have verified that the new liger-expert feature introduced in v0.8.0 is fully compatible with current training scripts.