### PR TITLE
fix: stop silently dropping weights when merging a Qwen3.5 LoRA

### DIFF
--- a/src/merge_lora_weights.py
+++ b/src/merge_lora_weights.py
@@ -1,12 +1,102 @@
 import argparse
+import json
+import re
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
 from utils import get_model_name_from_path, load_pretrained_model
+
+
+def _base_checkpoint_shards(base_path: Path):
+    index_path = base_path / "model.safetensors.index.json"
+    if index_path.exists():
+        weight_map = json.loads(index_path.read_text(encoding="utf-8"))["weight_map"]
+        return sorted({base_path / name for name in weight_map.values()})
+    return sorted(base_path.glob("model*.safetensors"))
+
+
+def _to_model_key(key, conversion_mapping):
+    """Rename a checkpoint key the way `from_pretrained` would."""
+    for pattern, replacement in conversion_mapping.items():
+        renamed = re.sub(pattern, replacement, key)
+        if renamed != key:
+            return renamed
+    return key
+
+
+def collect_base_only_tensors(model_base, model):
+    """Tensors that exist in the base checkpoint but not in the instantiated model.
+
+    Qwen3.5 ships a multi-token-prediction head (`mtp.*`, 15 tensors). It is listed in
+    `Qwen3_5PreTrainedModel._keys_to_ignore_on_load_unexpected`, so it is dropped on load
+    and never becomes a submodule. `save_pretrained` can only write what the module holds,
+    which means a merged checkpoint loses those tensors permanently and stops being a
+    drop-in replacement for the base model. Carry them over.
+
+    `_checkpoint_conversion_mapping` has to be applied first. Qwen2-VL and Qwen2.5-VL keep
+    their published checkpoints in the pre-refactor layout (`visual.*`, `model.*`) and
+    transformers renames them on load, so a naive key comparison would classify the whole
+    checkpoint as "missing from the model" and copy a second, unmerged, stale-layout copy
+    of every weight into the output.
+    """
+    base_path = Path(model_base)
+    if not base_path.is_dir():
+        print(f"Note: '{model_base}' is not a local directory; skipping the base-only weight check.")
+        return {}
+
+    shards = _base_checkpoint_shards(base_path)
+    if not shards:
+        print(f"Note: no safetensors shards found under {base_path}; skipping the base-only weight check.")
+        return {}
+
+    model_keys = set(model.state_dict())
+    conversion_mapping = getattr(type(model), "_checkpoint_conversion_mapping", None) or {}
+
+    extra = {}
+    total = 0
+    for shard in shards:
+        with safe_open(shard, framework="pt", device="cpu") as handle:
+            for key in handle.keys():
+                total += 1
+                if _to_model_key(key, conversion_mapping) not in model_keys:
+                    extra[key] = handle.get_tensor(key)
+
+    # Belt and braces: a genuinely extra head is a handful of tensors. If a large slice of
+    # the checkpoint looks unaccounted for, the key layouts do not line up for some reason
+    # this function does not know about -- keep the old behaviour rather than write a
+    # checkpoint with two copies of everything.
+    if extra and len(extra) > total // 4:
+        print(f"Warning: {len(extra)} of {total} base tensors have no counterpart in the model, "
+              f"which does not look like an extra head. Skipping the base-only weight copy.")
+        return {}
+
+    return extra
+
 
 def merge_lora(args):
     model_name = get_model_name_from_path(args.model_path)
     processor, model = load_pretrained_model(model_path=args.model_path, model_base=args.model_base,
                                              model_name=model_name, device_map='cpu')
 
-    model.save_pretrained(args.save_model_path, safe_serialization=args.safe_serialization)
+    state_dict = model.state_dict()
+    base_only = collect_base_only_tensors(args.model_base, model)
+    if base_only:
+        # The model is loaded in a fixed dtype, so the rest of the checkpoint may not be in
+        # the base checkpoint's dtype any more. Match it, otherwise the output is a
+        # mixed-dtype file that disagrees with its own config.
+        target_dtype = next((t.dtype for t in state_dict.values() if t.is_floating_point()), None)
+        if target_dtype is not None:
+            base_only = {k: (v.to(target_dtype) if v.is_floating_point() else v)
+                         for k, v in base_only.items()}
+        prefixes = sorted({key.split('.', 1)[0] for key in base_only})
+        print(f"Preserving {len(base_only)} tensor(s) that exist only in the base checkpoint "
+              f"(top-level prefixes: {prefixes}).")
+        state_dict.update(base_only)
+
+    model.save_pretrained(args.save_model_path, state_dict=state_dict,
+                          safe_serialization=args.safe_serialization)
     processor.save_pretrained(args.save_model_path)
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -69,8 +69,21 @@ def load_pretrained_model(model_path, model_base, model_name, load_8bit=False, l
         non_lora_trainables = {(k[11:] if k.startswith('base_model.') else k): v for k, v in non_lora_trainables.items()}
         if any(k.startswith('model.model.') for k in non_lora_trainables):
             non_lora_trainables = {(k[6:] if k.startswith('model.') else k): v for k, v in non_lora_trainables.items()}
-        model.load_state_dict(non_lora_trainables, strict=False)
-    
+        # `strict=False` is required here (the LoRA weights are loaded separately), but it
+        # also silently swallows every key that does not line up with the model. Those keys
+        # are trained weights -- typically the visual merger saved by `--freeze_merger
+        # False` -- so dropping them produces a model that quietly runs with the untrained
+        # base module and reports no error at all. Fail loudly instead.
+        load_result = model.load_state_dict(non_lora_trainables, strict=False)
+        if load_result.unexpected_keys:
+            preview = ', '.join(sorted(load_result.unexpected_keys)[:8])
+            raise RuntimeError(
+                f"{len(load_result.unexpected_keys)} of {len(non_lora_trainables)} tensors in "
+                f"non_lora_state_dict.bin match no parameter or buffer of the model and would "
+                f"have been discarded silently: {preview}. The merged model would keep the "
+                f"untrained weights for those modules."
+            )
+
         print('Loading LoRA weights...')
         model = PeftModel.from_pretrained(model, model_path)
 


### PR DESCRIPTION
Two independent ways the merge path loses weights without any warning.

1. `mtp.*` is dropped. Qwen3.5 ships a multi-token-prediction head (15 tensors in the 2B checkpoint). `Qwen3_5PreTrainedModel` lists it in `_keys_to_ignore_on_load_unexpected` and never builds it as a submodule, so `save_pretrained` cannot write it back and the merged directory stops being a drop-in replacement for the base model. Carry any base-only tensors over via `save_pretrained(state_dict=...)`, cast to the dtype the rest of the checkpoint was written in so the output is not a mixed-dtype file that disagrees with its own config.

   `_checkpoint_conversion_mapping` is applied before comparing keys, because Qwen2-VL and Qwen2.5-VL publish their checkpoints in the pre-refactor layout (`visual.*`, `model.*`) and transformers renames them on load. A naive comparison classifies the whole checkpoint as missing from the model -- measured on a Qwen2.5-VL config, 56 of 57 tensors -- and would write a second, unmerged, stale-layout copy of every weight. A fraction check keeps the old behaviour if a quarter of the checkpoint still looks unaccounted for.

2. `non_lora_state_dict.bin` can vanish into `strict=False`. The key prefix is rewritten with hard-coded character offsets (`k[11:]`, `k[6:]`) and the result of `load_state_dict` is discarded, so if the layout ever shifts the trained weights -- typically the visual merger saved by `--freeze_merger False` -- are dropped and the merged model quietly runs with the untrained base module. Raise on unexpected keys instead.

Verified end to end on a real Qwen3.5-2B LoRA checkpoint (LoRA r32 + trained visual merger):

  base checkpoint      632 tensors (15 mtp)
  merged, **before**       617 tensors ( 0 mtp)
  merged, **after**        632 tensors (15 mtp)

The 617 tensors the two outputs share are bit-identical, so nothing else about the merge changes. The recovered `mtp.*` values match the base to 3e-08 after the dtype cast, with no inf/nan. On a Qwen2.5-VL checkpoint written in the published layout, nothing is classified as base-only.

Unrelated observation from that run, not addressed here: the merge forces `torch_dtype=float16`, which also downcasts the 36 tensors the base keeps in float32 (`linear_attn.A_log` and `linear_attn.norm.weight`, matching `mamba_ssm_dtype: float32` in the config). No overflow, but it is a silent precision change. Happy to open a separate issue.