### PR TITLE
fix: make `--max_seq_length` actually take effect in SFT

### DIFF
--- a/src/dataset/sft_dataset.py
+++ b/src/dataset/sft_dataset.py
@@ -61,6 +61,10 @@ class SupervisedDataset(Dataset):
         self.video_resized_h = data_args.video_resized_height
         self.fps = data_args.fps
         self.nframes = data_args.nframes
+        # Upper bound on the per-sample token length. Over-length samples are right
+        # truncated so a single pathological example cannot blow up O(seq^2) attention
+        # memory. Defaults to the Qwen context size when the caller does not set it.
+        self.max_seq_length = getattr(data_args, "max_seq_length", None) or 32768
 
         self.model_type, self.image_patch_size, self.return_video_metadata = get_qwen_multimodal_settings(
             self.model_id
@@ -277,8 +281,28 @@ class SupervisedDataset(Dataset):
         labels = torch.cat(all_labels, dim=0).to(torch.long)
         mm_token_type_ids = torch.cat(all_mm_token_type_ids, dim=0).to(torch.long)
 
-        # eos_token_id = processor.tokenizer.convert_tokens_to_ids(DEFAULT_IM_END_TOKEN)
-        # input_ids, labels = truncate_sequence(input_ids, labels, self.max_length, eos_token_id)
+        # Enforce `--max_seq_length`. Only trailing TEXT is trimmed: the image/video
+        # placeholder tokens must keep matching the rows in pixel_values / image_grid_thw,
+        # so a sample whose media tokens already reach the limit is left untouched rather
+        # than silently desynchronised.
+        if input_ids.size(0) > self.max_seq_length:
+            mm_positions = (mm_token_type_ids != 0).nonzero(as_tuple=False)
+            last_mm_idx = int(mm_positions[-1]) if mm_positions.numel() > 0 else -1
+            # `get_mm_token_type_ids` returns all zeros whenever the processor does not
+            # produce `mm_token_type_ids`, so locate the placeholders by token id too --
+            # otherwise the guard silently does nothing on those models and the truncation
+            # cuts into the media tokens.
+            for media_token in (DEFAULT_IMAGE_TOKEN, DEFAULT_VIDEO_TOKEN):
+                media_token_id = processor.tokenizer.convert_tokens_to_ids(media_token)
+                if media_token_id is None or media_token_id < 0:
+                    continue
+                hits = (input_ids == media_token_id).nonzero(as_tuple=False)
+                if hits.numel() > 0:
+                    last_mm_idx = max(last_mm_idx, int(hits[-1]))
+            if self.max_seq_length > last_mm_idx + 1:
+                input_ids = input_ids[: self.max_seq_length]
+                labels = labels[: self.max_seq_length]
+                mm_token_type_ids = mm_token_type_ids[: self.max_seq_length]
 
         attention_mask = (input_ids > -1000000).to(torch.long)
 

--- a/src/train/train_sft.py
+++ b/src/train/train_sft.py
@@ -86,7 +86,11 @@ def train():
         (ModelArguments, DataArguments, TrainingArguments))
     
     model_args, data_args, training_args = parser.parse_args_into_dataclasses()
-    
+
+    # `--max_seq_length` is declared on TrainingArguments but the dataset is the only place
+    # that can enforce it, so hand it over explicitly.
+    data_args.max_seq_length = training_args.max_seq_length
+
     if data_args.nframes is not None and data_args.fps is not None:
         raise ValueError("You cannot set both `nframes` and `fps` at the same time. Please set only one of them.")
 


### PR DESCRIPTION
`max_seq_length` is documented on TrainingArguments as "Sequences will be right padded (and possibly truncated)", but nothing enforces it:

* `SupervisedDataset` never receives it -- `train_sft.py` does not copy it onto `data_args`.
* The only call site, `sft_dataset.py:281`, is commented out, and the `self.max_length` attribute it refers to does not exist on the class, so simply uncommenting it raises AttributeError.

A single runaway sample therefore drives the O(seq^2) attention memory with no cap at all, which shows up as an OOM many steps into a run.

Enforce the limit in the dataset, trimming only trailing text: the image and video placeholder tokens have to keep matching the rows of pixel_values / image_grid_thw, so a sample whose media tokens already reach the limit is left alone instead of being silently desynchronised. The placeholders are located by token id as well as by `mm_token_type_ids`, because `get_mm_token_type_ids` returns all zeros whenever the processor does not produce that field -- relying on it alone would make the guard a no-op on those models and truncate straight into the media tokens.

Repro on Qwen/Qwen3.5-2B with `max_seq_length=256`:

  long text answer   before: 6084 tokens ;  after: 256 tokens
  media over limit   left intact, 1024 placeholders == 1024 pixel rows
  same, with mm_token_type_ids forced to zeros: still 1024 == 1024

The same commented-out line exists in `cls_dataset.py:173`; left untouched here to keep this change reviewable.