### PR TITLE
feat: add --preserve_media_token_whitespace for structured media prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ bash scripts/finetune_lora_vision.sh
 - `--image_max_pixles` (int): Option for maximum maxmimum tokens for image.
 - `--video_min_pixels` (int): Option for minimum input tokens for video.
 - `--video_max_pixles` (int): Option for maximum maxmimum tokens for video.
+- `--preserve_media_token_whitespace` (bool): Keep the newlines written around `<image>`/`<video>` instead of collapsing them (default `False`, which matches the official Qwen chat template rendering). Turn it on when the layout around the media tokens carries meaning, e.g. `"Image 1: <image>\nImage 2: <image>\n\nTask: ..."`.
 - `--image_resized_width` (int): Option for setting the width of the input image.
 - `--image_resized_height` (int): Option for setting the height of the input image.
 - `--video_resized_width` (int): Option for setting the width of the input video.

--- a/src/dataset/data_utils.py
+++ b/src/dataset/data_utils.py
@@ -16,22 +16,36 @@ from constants import (
 )
 
 
-def replace_image_tokens(input_string, is_video=False):
+def replace_image_tokens(input_string, is_video=False, preserve_whitespace=False):
     if is_video:
-        pattern = r'\n*' + re.escape(LLAVA_VIDEO_TOKEN) + r'\n*'
+        token = LLAVA_VIDEO_TOKEN
         replacement = VISION_START_TOKEN + DEFAULT_VIDEO_TOKEN + VISION_END_TOKEN
     else:
-        pattern = r'\n*' + re.escape(LLAVA_IMAGE_TOKEN) + r'\n*'
+        token = LLAVA_IMAGE_TOKEN
         replacement = VISION_START_TOKEN + DEFAULT_IMAGE_TOKEN + VISION_END_TOKEN
 
-    return re.sub(pattern, replacement, input_string)
+    # Default: also swallow the newlines around the token, which matches how the official
+    # Qwen chat template renders a content list and keeps the classic LLaVA
+    # "<image>\nQuestion" datasets rendering exactly as they always have.
+    #
+    # With preserve_whitespace the author's layout is kept verbatim. This matters for
+    # structured multi-image prompts -- "Image 1: <image>\nImage 2: <image>\n\nTask: ..."
+    # otherwise collapses to "Image 1: <...>Image 2: <...>Task: ..." with no warning, and
+    # the training-time prompt stops matching whatever the same string renders to at
+    # inference time.
+    if preserve_whitespace:
+        return input_string.replace(token, replacement)
 
-def llava_to_openai(conversations, is_video=False):
+    return re.sub(r'\n*' + re.escape(token) + r'\n*', replacement, input_string)
+
+def llava_to_openai(conversations, is_video=False, preserve_whitespace=False):
     role_mapping = {"human": "user", "gpt": "assistant"}
 
     transformed_data = []
     for conversation in conversations:
-        transformed_content = replace_image_tokens(conversation["value"], is_video=is_video)
+        transformed_content = replace_image_tokens(
+            conversation["value"], is_video=is_video, preserve_whitespace=preserve_whitespace
+        )
         transformed_entry = {
             "role": role_mapping.get(conversation["from"], conversation["from"]),
             "content": transformed_content,

--- a/src/dataset/dpo_dataset.py
+++ b/src/dataset/dpo_dataset.py
@@ -158,7 +158,10 @@ class DPODataset(Dataset):
             all_input_ids.append(system_message_input_ids.squeeze(0))
             all_prompt_mm_token_type_ids.append(torch.zeros_like(system_message_input_ids, dtype=torch.long).squeeze(0))
 
-        user_prompt = replace_image_tokens(sources["prompt"], is_video=is_video)
+        user_prompt = replace_image_tokens(
+            sources["prompt"], is_video=is_video,
+            preserve_whitespace=getattr(self.data_args, 'preserve_media_token_whitespace', False),
+        )
         chosen_response = sources["chosen"]
         rejected_response = sources["rejected"]
         chosen_reasoning = sources.get("chosen_reasoning")

--- a/src/dataset/grpo_dataset.py
+++ b/src/dataset/grpo_dataset.py
@@ -133,7 +133,10 @@ class GRPODataset(Dataset):
             images=None
             videos=None
 
-        conversations = copy.deepcopy(llava_to_openai(sources['conversations'], is_video=is_video))
+        conversations = copy.deepcopy(llava_to_openai(
+            sources['conversations'], is_video=is_video,
+            preserve_whitespace=getattr(self.data_args, 'preserve_media_token_whitespace', False),
+        ))
 
         user_input = conversations[0]
         gpt_response = conversations[1]

--- a/src/dataset/sft_dataset.py
+++ b/src/dataset/sft_dataset.py
@@ -144,7 +144,10 @@ class SupervisedDataset(Dataset):
             images=None
             videos=None
 
-        sources = copy.deepcopy(llava_to_openai(sources['conversations'], is_video=is_video))
+        sources = copy.deepcopy(llava_to_openai(
+            sources['conversations'], is_video=is_video,
+            preserve_whitespace=getattr(self.data_args, 'preserve_media_token_whitespace', False),
+        ))
 
         all_input_ids = []
         all_labels = []

--- a/src/params.py
+++ b/src/params.py
@@ -311,3 +311,12 @@ class DataArguments:
         default=False,
         metadata={"help": "Enable reasoning-field parsing and model-specific <think> prompt formatting when supported."},
     )
+    preserve_media_token_whitespace: bool = field(
+        default=False,
+        metadata={
+            "help": "Keep the newlines you wrote around <image>/<video> instead of collapsing them. "
+                    "Off by default so existing datasets render exactly as before; turn it on when "
+                    "the prompt layout around the media tokens is meaningful (e.g. "
+                    "'Image 1: <image>\\nImage 2: <image>\\n\\nTask: ...')."
+        },
+    )


### PR DESCRIPTION
`replace_image_tokens` matches `\n*<image>\n*`, so every newline touching a media token is removed. For the classic LLaVA layout ("<image>\nQuestion") that is the right thing and matches how the official Qwen chat template renders a content list, so the default is unchanged.

It is wrong, silently, when the surrounding layout carries meaning:

  "Image 1: <image>\nImage 2: <image>\n\nTask: describe the change."
  -> "Image 1: <...>Image 2: <...>Task: describe the change."

"Image 2:" and "Task:" now run straight onto the preceding image block, and the training-time prompt no longer matches what the same string renders to at inference time -- which is easy to miss because nothing errors out.

Add an opt-in `--preserve_media_token_whitespace` (default False) threaded through the SFT, GRPO and DPO datasets. The README's two dataset examples are asserted to render byte-identically with the flag off.